### PR TITLE
fix: reverting AGP version back to 4.0.1 for backward compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'in.juspay:hypersdk.plugin:2.0.2'
     }
 }
@@ -47,7 +47,7 @@ android {
         }
     }
 
-    lint {
+    lintOptions {
         disable 'GradleCompatible'
     }
 


### PR DESCRIPTION
reverting AGP version back to 4.0.1 for backward compatibility for merchants still using older Gradle version in their app