### PR TITLE
fix(android): android gradle plugin 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import com.android.Version
+
 buildscript {
     repositories {
         google()
@@ -34,7 +36,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
     // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6    
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace = "in.juspay.hypersdkreact"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,12 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    // Check AGP version for backward compatibility w/react-native versions still on gradle plugin 6    
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace = "in.juspay.hypersdkreact"
+    }
+
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
     defaultConfig {


### PR DESCRIPTION
This is the minimum required change for this module to work on react-native 0.73 which includes android gradle plugin 8

It is backwards compatible with all previous versions of react-native that include android gradle plugin 7 or even 6 and older