### PR TITLE
fix: iOS popup disappearing issue with React Native modals

### DIFF
--- a/ios/HyperSdkReact.mm
+++ b/ios/HyperSdkReact.mm
@@ -327,7 +327,7 @@ RCT_EXPORT_METHOD(process:(NSString *)data) {
         @try {
             NSDictionary *jsonData = [HyperSdkReact stringToDictionary:data];
             // Update baseViewController if it's nil or not in the view hierarchy.
-            if (self.hyperInstance.baseViewController == nil || self.hyperInstance.baseViewController.view.window == nil) {
+            if (self.hyperInstance.baseViewController == nil || self.hyperInstance.baseViewController.view.window == nil || [self.hyperInstance.baseViewController isMemberOfClass:RCTModalHostViewController.class]) {
                 // Getting topViewController
                 id baseViewController = RCTPresentedViewController();
                 


### PR DESCRIPTION
Popups and overlays were disappearing when presented over React Native modals due to improper baseViewController handling.
Enhanced the baseViewController validation logic to detect and handle RCTModalHostViewController instances. The fix ensures that when a React Native modal is currently the base view controller, it gets replaced with a more stable view controller from the view hierarchy.